### PR TITLE
feature gates for collectors

### DIFF
--- a/helm/opencensus-collector-app/templates/configmap.yaml
+++ b/helm/opencensus-collector-app/templates/configmap.yaml
@@ -8,15 +8,23 @@ metadata:
 data:
   oc-collector-config: |
     receivers:
+{{- if .Values.enableOpencensusReceiver }}
       opencensus:
-        port: 55678
+        port: {{ .Values.ports.opencensusReceiver }}
         keepalive:
           server-parameters:
             max-connection-age: 120s
-            max-connection-age-grace: 30s            
+            max-connection-age-grace: 30s
+{{- end }}
+{{- if .Values.enableZipkinReceiver }}
       zipkin:
-        port: 9411
-      jaeger: {}
+        port: {{ .Values.ports.zipkinReceiver }}
+{{- end }}
+{{- if .Values.enableJaegerReceiver }}
+      jaeger:
+        jaeger-thrift-tchannel-port: {{ .Values.ports.jaegerReceiverTChannel }}
+        jaeger-thrift-http-port: {{ .Values.ports.jaegerReceiverHTTP }}
+{{- end }}
     queued-exporters:
       jaeger:
         num-workers: 4
@@ -24,5 +32,5 @@ data:
         retry-on-failure: true
         sender-type: jaeger-thrift-http
         jaeger-thrift-http:
-          collector-endpoint: http://jaeger.tracing:14268/api/traces
+          collector-endpoint: {{ .Values.jaegerURL }}
           timeout: 5s

--- a/helm/opencensus-collector-app/templates/deployment.yaml
+++ b/helm/opencensus-collector-app/templates/deployment.yaml
@@ -29,18 +29,17 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-        resources:
-          limits:
-            cpu: 1
-            memory: 2Gi
-          requests:
-            cpu: 200m
-            memory: 400Mi
         ports:
-        - containerPort: 55678
-#        - containerPort: 14267
-#        - containerPort: 14268
-#        - containerPort: 9411
+{{- if .Values.enableOpencensusReceiver }}
+        - containerPort: {{ .Values.ports.opencensusReceiver }}
+{{- end }}
+{{- if .Values.enableJaegerReceiver }}
+        - containerPort: {{ .Values.ports.jaegerReceiverTChannel }}
+        - containerPort: {{ .Values.ports.jaegerReceiverHTTP }}
+{{- end }}
+{{- if .Values.enableZipkinReceiver }}
+        - containerPort: {{ .Values.ports.zipkinReceiver }}
+{{- end }}
         volumeMounts:
         - name: oc-collector-config-vol
           mountPath: /conf

--- a/helm/opencensus-collector-app/templates/service.yaml
+++ b/helm/opencensus-collector-app/templates/service.yaml
@@ -7,15 +7,21 @@ metadata:
 {{ include "opencensus-collector-app.labels" . | indent 4 }}
 spec:
   ports:
+{{- if .Values.enableOpencensusReceiver }}
   - name: opencensus
-    port: 55678
+    port: {{ .Values.ports.opencensusReceiver }}
     protocol: TCP
-    targetPort: 55678
-#  - name: jaeger-tchannel
-#    port: 14267
-#  - name: jaeger-thrift-http
-#    port: 14268
-#  - name: zipkin
-#    port: 9411
+    targetPort: {{ .Values.ports.opencensusReceiver }}
+{{- end }}
+{{- if .Values.enableJaegerReceiver }}
+  - name: jaeger-tchannel
+    port: {{ .Values.ports.jaegerReceiverTChannel }}
+  - name: jaeger-thrift-http
+    port: {{ .Values.ports.jaegerReceiverHTTP }}
+{{- end }}
+{{- if .Values.enableZipkinReceiver }}
+  - name: zipkin
+    port: {{ .Values.ports.zipkinReceiver }}
   selector:
+{{- end }}
 {{ include "opencensus-collector-app.labels" . | indent 4 }}

--- a/helm/opencensus-collector-app/values.yaml
+++ b/helm/opencensus-collector-app/values.yaml
@@ -23,3 +23,15 @@ resources:
   requests:
     cpu: 200m
     memory: 512Mi
+
+enableOpencensusReceiver: true
+enableZipkinReceiver: true
+enableJaegerReceiver: true
+
+ports:
+  opencensusReceiver: 55678
+  zipkinReceiver: 9411
+  jaegerReceiverTChannel: 14267
+  jaegerReceiverHTTP: 14268
+
+jaegerURL: http://jaeger.tracing:14268/api/traces


### PR DESCRIPTION
This PR adds:
- `enable*Receiver` flags to enable configuration of different incoming protocols (collectors)
- templated port numbers for collectors (to avoid typos)
- configurable upstream Jaeger server URL